### PR TITLE
fix SelectedSpell hooks

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -40,14 +40,14 @@
     {
       "n": "setSelectedSpellChildIndex",
       "c": "client",
-      "p": "sv",
-      "m": 290948069
+      "p": "st",
+      "m": 1167624643
     },
     {
       "n": "setSelectedSpellItemId",
       "c": "client",
-      "p": "st",
-      "m": 1167624643
+      "p": "sv",
+      "m": 290948069
     },
     {
       "n": "getOldNpcOverheadArray",


### PR DESCRIPTION
selected spell child index / item id hooks were wrong away around


for spells this doesnt actually matter i guess. but i sometimes use the hooks for inventory actiopns